### PR TITLE
Fix unawaited coroutine when creating users

### DIFF
--- a/finanze/infrastructure/user_files/user_data_manager.py
+++ b/finanze/infrastructure/user_files/user_data_manager.py
@@ -119,7 +119,7 @@ class UserDataManager(DataManager):
         return None
 
     async def create_user(self, user: UserRegistration) -> User:
-        if self.get_user(user.username):
+        if await self.get_user(user.username):
             raise UserAlreadyExists(
                 f"User with username '{user.username}' already exists."
             )


### PR DESCRIPTION
Fix `create_user` to await `get_user` check for async consistency (to avoid raising UserAlreadyExists)