### PR TITLE
fix: hide sensitive cryptocurrency values in DashboardPage

### DIFF
--- a/frontend/app/src/pages/DashboardPage.tsx
+++ b/frontend/app/src/pages/DashboardPage.tsx
@@ -2234,15 +2234,17 @@ export default function DashboardPage() {
                                         </span>
                                         <div className="flex items-center gap-2">
                                           <span className="text-xs text-muted-foreground whitespace-nowrap">
-                                            {item.amount?.toLocaleString(
-                                              locale,
-                                              {
-                                                minimumFractionDigits:
-                                                  item.amount < 1 ? 6 : 2,
-                                                maximumFractionDigits:
-                                                  item.amount < 1 ? 6 : 2,
-                                              },
-                                            )}{" "}
+                                            <Sensitive>
+                                              {item.amount?.toLocaleString(
+                                                locale,
+                                                {
+                                                  minimumFractionDigits:
+                                                    item.amount < 1 ? 6 : 2,
+                                                  maximumFractionDigits:
+                                                    item.amount < 1 ? 6 : 2,
+                                                },
+                                              )}
+                                            </Sensitive>{" "}
                                             {item.symbol}
                                           </span>
                                           <span className="font-semibold whitespace-nowrap text-sm">
@@ -2794,15 +2796,21 @@ export default function DashboardPage() {
                                                   Amount:
                                                 </span>
                                                 <div className="font-semibold">
-                                                  {item.amount?.toLocaleString(
-                                                    locale,
-                                                    {
-                                                      minimumFractionDigits:
-                                                        item.amount < 1 ? 6 : 2,
-                                                      maximumFractionDigits:
-                                                        item.amount < 1 ? 6 : 2,
-                                                    },
-                                                  )}{" "}
+                                                  <Sensitive>
+                                                    {item.amount?.toLocaleString(
+                                                      locale,
+                                                      {
+                                                        minimumFractionDigits:
+                                                          item.amount < 1
+                                                            ? 6
+                                                            : 2,
+                                                        maximumFractionDigits:
+                                                          item.amount < 1
+                                                            ? 6
+                                                            : 2,
+                                                      },
+                                                    )}
+                                                  </Sensitive>{" "}
                                                   {item.symbol}
                                                 </div>
                                               </div>


### PR DESCRIPTION
The values associated with crypto were displayed when Sensitive Mode was turned on.

Before:
<img width="596" height="440" alt="image" src="https://github.com/user-attachments/assets/8b935399-6096-4bd5-9af0-717782a3b359" />

After:
<img width="596" height="440" alt="image" src="https://github.com/user-attachments/assets/d8a4fdb9-ff14-4e81-9c1a-73305dff5f57" />
